### PR TITLE
Filter bets

### DIFF
--- a/app/Http/Livewire/BetIndex.php
+++ b/app/Http/Livewire/BetIndex.php
@@ -13,6 +13,15 @@ class BetIndex extends Component
     public $showDeleteModal = false;
     // public $showEditModal = false;
     public Bet $currentBet;
+    public $search = '';
+    public $win_checkbox;
+    public $loss_checkbox;
+    public $na_checkbox;
+
+    public function updatingSearch()
+    {
+        $this->resetPage();
+    }
 
     public function mount()
     {
@@ -22,7 +31,7 @@ class BetIndex extends Component
     public function render()
     {
         return view('livewire.bet-index', [
-            'bets' => Bet::where('user_id', '=', auth()->id() )->latest()->paginate(20),
+            'bets' => Bet::where('user_id', '=', auth()->id() )->filter($this->search, $this->win_checkbox, $this->loss_checkbox, $this->na_checkbox)->latest()->paginate(20),
             'optional_attributes' => Bet::$optional_attributes
         ]);
     }

--- a/app/Models/Bet.php
+++ b/app/Models/Bet.php
@@ -28,15 +28,15 @@ class Bet extends Model
 
         })->where(function ($query) use($win_checkbox, $loss_checkbox, $na_checkbox) {
 
-            $query->when($win_checkbox, function ($query, $win_checkbox) {
+            $query->when($win_checkbox, function ($query) {
 
                 $query->where('result', true);
 
-            })->when($loss_checkbox, function ($query, $loss_checkbox) {
+            })->when($loss_checkbox, function ($query) {
                 
                 $query->orWhere('result', false);
 
-            })->when($na_checkbox, function ($query, $na_checkbox) {
+            })->when($na_checkbox, function ($query) {
                 
                 $query->orWhere('result', null);
 

--- a/app/Models/Bet.php
+++ b/app/Models/Bet.php
@@ -5,8 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\User;
-use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Bet extends Model
 {
@@ -17,29 +15,35 @@ class Bet extends Model
     // array of attributes that are optional to display (both in DB and index view)
     public static $optional_attributes = ['bookie', 'sport', 'match_date', 'match_time', 'bet_type', 'bet_pick', 'bet_description'];
 
-    /**
-     * Set match_time format to H:i so that it is consistent with input time
-     *
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute
-     */
-    // protected function matchTime(): Attribute
-    // {
-    //     return Attribute::make(
-    //         get: fn ($value) => Carbon::createFromFormat('H:i:s', $value)->format('H:i'),
-    //     );
-    // }
+    public function scopeFilter($query, string $search, ?bool $win_checkbox, ?bool $loss_checkbox, ?bool $na_checkbox)
+    {
+        $query->where(function ($query) use($search) {
 
-    /**
-     * Set match_time format to H:i so that it is consistent with input time
-     *
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute
-     */
-    // protected function matchDate(): Attribute
-    // {
-    //     return Attribute::make(
-    //         get: fn ($value) => Carbon::createFromFormat('Y-m-d', $value)->format('m-d-Y'),
-    //     );
-    // }
+            $query->where('match', 'like', '%' . $search . '%')
+                ->orWhere('bookie', 'like', '%' . $search . '%')
+                ->orWhere('sport', 'like', '%' . $search . '%')
+                ->orWhere('bet_type', 'like', '%' . $search . '%')
+                ->orWhere('bet_pick', 'like', '%' . $search . '%')
+                ->orWhere('bet_description', 'like', '%' . $search . '%');
+
+        })->where(function ($query) use($win_checkbox, $loss_checkbox, $na_checkbox) {
+
+            $query->when($win_checkbox, function ($query, $win_checkbox) {
+
+                $query->where('result', true);
+
+            })->when($loss_checkbox, function ($query, $loss_checkbox) {
+                
+                $query->orWhere('result', false);
+
+            })->when($na_checkbox, function ($query, $na_checkbox) {
+                
+                $query->orWhere('result', null);
+
+            });
+
+        });
+    }
 
     public function payoff()
     {

--- a/resources/views/auth/edit-profile.blade.php
+++ b/resources/views/auth/edit-profile.blade.php
@@ -48,12 +48,13 @@
             <!-- Odd Type -->
             <div class="flex items-center mt-4">
 
-                <input class="mr-1" type="radio" name="odd_type" id="american"
-                    {{ old('odd_type', auth()->user()->odd_type) == 'american' ? 'checked' : '' }} value="american">
+                <input class="mr-1" type="radio" name="odd_type" id="american" @checked(old('odd_type', auth()->user()->odd_type) === 'american')
+                    value="american">
+
                 <x-input-label for="american" :value="__('American')" />
 
-                <input class="ml-4 mr-1" type="radio" name="odd_type" id="decimal"
-                    {{ old('odd_type', auth()->user()->odd_type) == 'decimal' ? 'checked' : '' }} value="decimal">
+                <input class="ml-4 mr-1" type="radio" name="odd_type" id="decimal" @checked(old('odd_type', auth()->user()->odd_type) === 'decimal')
+                    value="decimal">
                 <x-input-label for="decimal" :value="__('Decimal')" />
 
             </div>

--- a/resources/views/livewire/bet-index.blade.php
+++ b/resources/views/livewire/bet-index.blade.php
@@ -157,11 +157,11 @@
                     <a href="/bets/{{ $bet->id }}/edit">
                         <svg class="w-4" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg"
                             xmlns:xlink="http://www.w3.org/1999/xlink">
-                            <g id="Page-1" stroke="none" stroke-width="1" fill="#9b9b9b" fill-rule="evenodd">
-                                <g id="icon-shape">
+                            <g stroke="none" stroke-width="1" fill="#9b9b9b" fill-rule="evenodd">
+                                <g>
                                     <path
-                                        d="M12.2928932,3.70710678 L0,16 L0,20 L4,20 L16.2928932,7.70710678 L12.2928932,3.70710678 Z M13.7071068,2.29289322 L16,0 L20,4 L17.7071068,6.29289322 L13.7071068,2.29289322 Z"
-                                        id="Combined-Shape"></path>
+                                        d="M12.2928932,3.70710678 L0,16 L0,20 L4,20 L16.2928932,7.70710678 L12.2928932,3.70710678 Z M13.7071068,2.29289322 L16,0 L20,4 L17.7071068,6.29289322 L13.7071068,2.29289322 Z">
+                                    </path>
                                 </g>
                             </g>
                         </svg>
@@ -171,12 +171,11 @@
                     <button wire:click="confirmDelete({{ $bet->id }})" class="mt-4" type="button">
                         <svg class="w-4 "viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg"
                             xmlns:xlink="http://www.w3.org/1999/xlink">
-                            <g id="Page-1" stroke="none" stroke-width="1" fill="#d76565" fill-rule="evenodd">
-                                <g id="icon-shape">
+                            <g stroke="none" stroke-width="1" fill="#d76565" fill-rule="evenodd">
+                                <g>
                                     <path
-                                        d="M2,2 L18,2 L18,4 L2,4 L2,2 Z M8,0 L12,0 L14,2 L6,2 L8,0 Z M3,6 L17,6 L16,20 L4,20 L3,6 Z M8,8 L9,8 L9,18 L8,18 L8,8 Z M11,8 L12,8 L12,18 L11,18 L11,8 Z"
-                                        id="Combined-Shape"></path>
-
+                                        d="M2,2 L18,2 L18,4 L2,4 L2,2 Z M8,0 L12,0 L14,2 L6,2 L8,0 Z M3,6 L17,6 L16,20 L4,20 L3,6 Z M8,8 L9,8 L9,18 L8,18 L8,8 Z M11,8 L12,8 L12,18 L11,18 L11,8 Z">
+                                    </path>
                                 </g>
                             </g>
                         </svg>

--- a/resources/views/livewire/bet-index.blade.php
+++ b/resources/views/livewire/bet-index.blade.php
@@ -5,35 +5,62 @@
         </h2>
     </x-slot>
 
+
     <div class="max-w-5xl mx-auto py-4 px-4 sm:px-6 lg:px-8 space-y-4 bg-gray-100">
 
-        <div class="flex justify-center">
-            <div class="mb-3 xl:w-96">
-              <div class="input-group relative flex items-stretch w-full rounded">
-                <input type="search" name="search" class="form-control relative flex-auto min-w-0 block w-full px-3 py-1.5 text-base font-normal text-gray-700 bg-white bg-clip-padding border border-solid border-gray-300 rounded transition ease-in-out m-0 focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none" placeholder="Search" aria-label="Search" aria-describedby="button-addon2">
-                <span class="input-group-text flex items-center px-3 py-1.5 text-base font-normal text-gray-700 text-center whitespace-nowrap rounded" id="basic-addon2">
-                  <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="search" class="w-4" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-                    <path fill="currentColor" d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"></path>
-                  </svg>
-                </span>
-              </div>
+        <div class="sm:flex sm:items-center sm:justify-between">
+            <div class="flex items-center mb-4 sm:mb-0">
+                {{-- new bet link --}}
+                <a href="/bets/create"
+                    class="bg-blue-900 font-semibold hover:opacity-75 py-2 rounded-lg text-center text-white w-1/2 sm:w-20">
+                    <p class="text-sm">
+                        New Bet
+                    </p>
+                </a>
+
+                {{-- stats link --}}
+                <a href="/stats"
+                    class="ml-4 bg-blue-900 font-semibold hover:opacity-75 py-2 rounded-lg text-center text-white w-1/2 sm:w-20">
+                    <p class="text-sm">
+                        Stats
+                    </p>
+                </a>
             </div>
-          </div>
 
-        <div class="flex items-center">
-            {{-- new bet link --}}
-            <a href="/bets/create" class="text-white font-semibold rounded-lg bg-blue-900 p-2 hover:opacity-75">
-                <p class="text-sm">
-                    New Bet
-                </p>
-            </a>
+            {{-- search bar --}}
+            <div class="flex sm:justify-center">
+                <div class="mb-1 xl:w-96 w-full">
+                    <div class="input-group relative flex items-stretch w-full rounded">
+                        <input wire:model="search" type="search" name="search"
+                            class="form-control relative flex-auto min-w-0 block w-full px-3 py-1.5 text-base font-normal text-gray-700 bg-white bg-clip-padding border border-solid border-gray-300 rounded transition ease-in-out m-0 focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none"
+                            placeholder="Search" aria-label="Search" aria-describedby="button-addon2">
+                        <span
+                            class="input-group-text hidden sm:flex items-center px-3 py-1.5 text-base font-normal text-gray-700 text-center whitespace-nowrap rounded"
+                            id="basic-addon2">
+                            <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="search"
+                                class="w-4" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                                <path fill="currentColor"
+                                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z">
+                                </path>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
 
-            {{-- stats link --}}
-            <a href="/stats" class="ml-4 text-white font-semibold rounded-lg bg-blue-900 p-2 hover:opacity-75">
-                <p class="text-sm">
-                    Stats
-                </p>
-            </a>
+        <div class="flex justify-end sm:mr-4">
+            <input wire:model="win_checkbox" type="checkbox" name="win" id="win"
+                class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+            <label for="win" class="ml-1 mr-4 text-sm text-gray-600">Win</label>
+
+            <input wire:model="loss_checkbox" type="checkbox" name="loss" id="loss"
+                class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+            <label for="loss" class="ml-1 mr-4 text-sm text-gray-600">Loss</label>
+
+            <input wire:model="na_checkbox" type="checkbox" name="na" id="na"
+                class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+            <label for="na" class="ml-1 sm:mr-6 text-sm text-gray-600">N/A</label>
         </div>
 
         {{-- success flash message --}}

--- a/resources/views/livewire/bet-index.blade.php
+++ b/resources/views/livewire/bet-index.blade.php
@@ -7,6 +7,19 @@
 
     <div class="max-w-5xl mx-auto py-4 px-4 sm:px-6 lg:px-8 space-y-4 bg-gray-100">
 
+        <div class="flex justify-center">
+            <div class="mb-3 xl:w-96">
+              <div class="input-group relative flex items-stretch w-full rounded">
+                <input type="search" name="search" class="form-control relative flex-auto min-w-0 block w-full px-3 py-1.5 text-base font-normal text-gray-700 bg-white bg-clip-padding border border-solid border-gray-300 rounded transition ease-in-out m-0 focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none" placeholder="Search" aria-label="Search" aria-describedby="button-addon2">
+                <span class="input-group-text flex items-center px-3 py-1.5 text-base font-normal text-gray-700 text-center whitespace-nowrap rounded" id="basic-addon2">
+                  <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="search" class="w-4" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                    <path fill="currentColor" d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"></path>
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </div>
+
         <div class="flex items-center">
             {{-- new bet link --}}
             <a href="/bets/create" class="text-white font-semibold rounded-lg bg-blue-900 p-2 hover:opacity-75">

--- a/tests/Feature/Bets/BetTest.php
+++ b/tests/Feature/Bets/BetTest.php
@@ -2,15 +2,24 @@
 
 namespace Tests\Feature\Bets;
 
+use App\Http\Livewire\BetIndex;
 use App\Models\Bet;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class BetTest extends TestCase
 {
     use WithFaker, RefreshDatabase;
+
+    public function test_bet_index_livewire_component_exists()
+    {
+        $response = $this->actingAs(User::factory()->create())->get('/bets');
+
+        $response->assertStatus(200);
+    }
 
     public function test_bets_can_be_created()
     {
@@ -205,5 +214,18 @@ class BetTest extends TestCase
         $this->assertDatabaseHas('bets', $bet_array);
 
         $this->get('/bets')->assertSee("Bet updated!");
+    }
+
+    public function test_user_can_delete_bet()
+    {
+        $this->actingAs(User::factory()->create());
+
+        $bet = Bet::factory()->create();
+
+        Livewire::test(BetIndex::class)
+            ->call('confirmDelete', $bet->id)
+            ->assertSee('Are you sure?')
+            ->call('deleteBet')
+            ->assertSee('Bet deleted!');
     }
 }


### PR DESCRIPTION
Adds functionality to filter bets by search input (which searches all bet text fields) and by result. It also fixes delete and edit svg icons disappearing when toggling filters - this was done by deleting the id's from the svg's, which were repeated multiple times in the BetIndex component.