### PR TITLE
Payout calculator

### DIFF
--- a/app/Http/Controllers/BetController.php
+++ b/app/Http/Controllers/BetController.php
@@ -169,7 +169,7 @@ class BetController extends Controller
 
         foreach ($bets as $bet) {
             if ($bet->result === 1) {
-                $profitArray[] = $bet->payoff() - $bet->bet_size;
+                $profitArray[] = $bet->payout() - $bet->bet_size;
             } else if ($bet->result === 0) {
                 $profitArray[] = - ((float) $bet->bet_size);
             }
@@ -278,7 +278,7 @@ class BetController extends Controller
             'totalGains' =>  Bet::where('user_id', auth()->user()->id)
                 ->where('result', 1)
                 ->get()
-                ->map(fn ($bet) => $bet->payoff() - $bet->bet_size)
+                ->map(fn ($bet) => $bet->payout() - $bet->bet_size)
                 ->sum(),
 
             'totalLosses' =>  Bet::where('user_id', auth()->user()->id)
@@ -289,10 +289,10 @@ class BetController extends Controller
             'biggestBet' => Bet::where('user_id', auth()->user()->id)
                 ->max('bet_size'),
 
-            'biggestPayoff' => Bet::where('user_id', auth()->user()->id)
+            'biggestPayout' => Bet::where('user_id', auth()->user()->id)
                 ->where('result', 1)
                 ->get()
-                ->map(fn ($bet) => $bet->payoff())
+                ->map(fn ($bet) => $bet->payout())
                 ->max(),
 
             'biggestLoss' => Bet::where('user_id', auth()->user()->id)

--- a/app/Models/Bet.php
+++ b/app/Models/Bet.php
@@ -43,7 +43,7 @@ class Bet extends Model
         });
     }
 
-    public function payoff()
+    public function payout()
     {
         return $this->decimal_odd * $this->bet_size;
     }

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -41,6 +41,14 @@
             </p>
         </div>
 
+        <div class="mb-6 w-full">
+            <h3 class="font-bold text-lg">Payout Calculator</h3>
+
+            <p class="text-sm">
+                If you want to quickly calculate the potential payout of a bet, you can use our <a href="{{ route('payout-calculator') }}"><span class="text-blue-500">Payout Calculator</span></a> tool to check the expected payout and profit. 
+            </p>
+        </div>
+
         <h3 class="font-bold text-lg">Bets</h3>
 
         <div class="mb-6 w-full">

--- a/resources/views/bets/stats.blade.php
+++ b/resources/views/bets/stats.blade.php
@@ -64,8 +64,8 @@
             {{-- biggest bet --}}
             <x-stat-card name='Biggest Bet' :value="(new NumberFormatter('en_US', NumberFormatter::CURRENCY))->formatCurrency($biggestBet, 'USD')" />
 
-            {{-- biggest payoff --}}
-            <x-stat-card name='Biggest Payoff' :value="(new NumberFormatter('en_US', NumberFormatter::CURRENCY))->formatCurrency($biggestPayoff, 'USD')" />
+            {{-- biggest payout --}}
+            <x-stat-card name='Biggest Payout' :value="(new NumberFormatter('en_US', NumberFormatter::CURRENCY))->formatCurrency($biggestPayout, 'USD')" />
 
             {{-- biggest loss --}}
             <x-stat-card name='Biggest Loss' :value="(new NumberFormatter('en_US', NumberFormatter::CURRENCY))->formatCurrency($biggestLoss, 'USD')" />

--- a/resources/views/components/bet-card.blade.php
+++ b/resources/views/components/bet-card.blade.php
@@ -157,24 +157,24 @@
             @if (isset($bet->result))
                 {{-- if win --}}
                 @if ($bet->result)
-                    {{-- bet payoff --}}
+                    {{-- bet payout --}}
                     <div>
                         <p>
-                            <span class="text-xs">Payoff:</span>
+                            <span class="text-xs">Payout:</span>
                         </p>
 
                         <p>
                             <span
-                                class="text-md  font-semibold">{{ (new NumberFormatter('en_US', NumberFormatter::CURRENCY))->formatCurrency($bet->payoff(), 'USD') }}</span>
+                                class="text-md  font-semibold">{{ (new NumberFormatter('en_US', NumberFormatter::CURRENCY))->formatCurrency($bet->payout(), 'USD') }}</span>
                         </p>
                     </div>
 
                     {{-- if loss --}}
                 @else
-                    {{-- bet payoff --}}
+                    {{-- bet payout --}}
                     <div>
                         <p>
-                            <span class="text-xs">Payoff:</span>
+                            <span class="text-xs">Payout:</span>
                         </p>
                         <p>
                             <span class="text-md font-semibold">$0</span>
@@ -184,14 +184,14 @@
 
                 {{-- if there is no result yet --}}
             @else
-                {{-- potential bet payoff --}}
+                {{-- potential bet payout --}}
                 <div>
                     <p>
-                        <span class="text-xs">Potential Payoff:</span>
+                        <span class="text-xs">Potential Payout:</span>
                     </p>
                     <p>
                         <span
-                            class="text-md font-semibold">{{ (new NumberFormatter('en_US', NumberFormatter::CURRENCY))->formatCurrency($bet->payoff(), 'USD') }}</span>
+                            class="text-md font-semibold">{{ (new NumberFormatter('en_US', NumberFormatter::CURRENCY))->formatCurrency($bet->payout(), 'USD') }}</span>
                     </p>
                 </div>
             @endif

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -70,6 +70,11 @@
                                 {{ __('Odd Converter') }}
                             </x-dropdown-link>
 
+                            {{-- payout calculator --}}
+                            <x-dropdown-link :href="route('payout-calculator')" :active="request()->routeIs('payout-calculator')">
+                                {{ __('Payout Calculator') }}
+                            </x-dropdown-link>
+
                         </x-slot>
                     </x-dropdown>
                 </div>
@@ -236,6 +241,11 @@
                             {{ __('Odd Converter') }}
                         </x-responsive-nav-link>
 
+                        {{-- payout calculator --}}
+                        <x-responsive-nav-link class="pl-6" :href="route('payout-calculator')" :active="request()->routeIs('payout-calculator')">
+                            {{ __('Payout Calculator') }}
+                        </x-responsive-nav-link>
+
                     </div>
 
                 </div>
@@ -342,6 +352,11 @@
                         {{-- odd converter page link --}}
                         <x-responsive-nav-link class="pl-6" :href="route('odd-converter')" :active="request()->routeIs('odd-converter')">
                             {{ __('Odd Converter') }}
+                        </x-responsive-nav-link>
+
+                        {{-- odd payout calculator --}}
+                        <x-responsive-nav-link class="pl-6" :href="route('payout-calculator')" :active="request()->routeIs('payout-calculator')">
+                            {{ __('Payout Calculator') }}
                         </x-responsive-nav-link>
 
                     </div>

--- a/resources/views/payout-calculator.blade.php
+++ b/resources/views/payout-calculator.blade.php
@@ -1,0 +1,228 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-sm text-white leading-tight">
+            {{ __('Payout Calculator') }}
+        </h2>
+    </x-slot>
+
+    <x-auth-card class="sm:max-w-lg">
+
+        <p class="text-xl font-semibold">Payout Calculator</p>
+
+        <p class="font-medium text-sm text-gray-700">
+            Calculate the payout from a bet.
+        </p>
+
+        <p class="font-medium text-sm mt-5 mb-1">
+            Odd Format:
+        </p>
+
+        <!-- Odd Type -->
+        <div class="flex items-center">
+
+            <input class="mr-1" type="radio" name="odd_type" id="american" value="american" required>
+            <x-input-label for="american" :value="__('American')" />
+
+            <input class="ml-4 mr-1" type="radio" name="odd_type" id="decimal" value="decimal">
+            <x-input-label for="decimal" :value="__('Decimal')" />
+
+        </div>
+
+        {{-- checkbox error --}}
+        <span class="block mt-1 text-red-500 text-xs" id="odd_type_error" style="display: none;"></span>
+
+
+        <div class="space-y-2 mt-6">
+
+            {{-- odd --}}
+            <x-input-label for="odd" :value="__('Odd')" />
+            <x-text-input id="odd" class="block mt-1 w-full" type="number" step="0.001" name="odd" />
+
+            {{-- odd error --}}
+            <span class="block mt-1 text-red-500 text-xs" id="odd_error" style="display: none"></span>
+
+
+            {{-- stake --}}
+            <x-input-label for="stake" :value="__('Stake')" />
+            <x-text-input id="stake" class="block mt-1 w-full" type="number" step="0.01" name="stake" />
+
+            {{-- stake error --}}
+            <span class="block mt-1 text-red-500 text-xs" id="stake_error" style="display: none;"></span>
+
+        </div>
+
+        <x-primary-button type="button" class="mt-4" id="btn">Convert</x-primary-button>
+
+        <span class="bg-gray-400 block font-semibold mt-4 p-2 rounded-sm text-center text-white" id="payout"
+            style="display: none"></span>
+
+        <span class="bg-gray-400 block font-semibold mt-4 p-2 rounded-sm text-center text-white" id="profit"
+            style="display: none"></span>
+
+        <p class="border-gray-200 border-t-2 mt-6 pt-4 text-gray-700 text-sm">
+            Being able to calculate the returns for any single bet is an essential part of betting.
+            This might be one of the simplest calculations done in betting, nut it is nonetheless essential. Our <span
+                class="italic">Payout Calculator</span> makes this calculation even simpler!
+        </p>
+
+        <p class="text-gray-700 text-sm mt-3">
+            Every bet can essentially be broken down into three elements: the <strong>stake</strong>, the
+            <strong>payout</strong>, and the <strong>profit</strong>.
+            The stake is the amount being wagered on the bet, this is the amount you risk losing whenever you place a
+            bet. On the other hand, the payout is the amount you can win. This consistis of the stake plus the
+            <strong>profit</strong>, which is how much money the bookies are giving you for winning the bet.
+        </p>
+
+        <p class="text-gray-700 text-sm mt-3">
+            For instance, lets suppose Barcelona and Real Madrid are competing in the Champions League Final. A bookie
+            has the odds of Real Madrid winning the match at 2.3, in decimal format. This means that, if you stake a 100
+            dollars on Real Madrid to win the match, then your potential payout is of 230 dollars and your potential
+            profit is of 130 dollars.
+        </p>
+
+        <p class="text-gray-700 text-sm mt-5">
+            The following formulas can be used to calculate the payout.
+        </p>
+
+        <p class="text-gray-700 text-sm mt-3 font-semibold">
+            Formula for decimal odds:
+        </p>
+
+        <p class="bg-gray-700 py-4 rounded-sm text-center text-gray-200 text-sm mt-3">
+            Payout &nbsp; = &nbsp; Stake &nbsp; x &nbsp; Odd
+        </p>
+
+        <p class="text-gray-700 text-sm mt-3 font-semibold">
+            Formula for american odds:
+        </p>
+
+        <p class="text-gray-700 text-sm mt-1">
+            Favorite (-):
+        </p>
+
+        <p class="bg-gray-700 py-4 rounded-sm text-center text-gray-200 text-sm mt-3">
+            Payout &nbsp; = &nbsp; ( Stake / (Odd / -100) ) &nbsp; + &nbsp; Stake
+        </p>
+
+        <p class="text-gray-700 text-sm mt-3">
+            Underdog (+):
+        </p>
+
+        <p class="bg-gray-700 py-4 rounded-sm text-center text-gray-200 text-sm mt-3">
+            Payout &nbsp; = &nbsp; Stake &nbsp; x &nbsp; (Odd / 100) &nbsp; + &nbsp; Stake
+        </p>
+
+        <p class="text-gray-700 text-sm mt-5">
+            Once the payout is known, the profit can be easily calculated by subtracting stake from it.
+        </p>
+
+        <p class="text-gray-700 text-sm mt-3 font-semibold">
+            Formula for profit:
+        </p>
+
+        <p class="bg-gray-700 py-4 rounded-sm text-center text-gray-200 text-sm mt-3">
+            Profit &nbsp; = &nbsp; Payout &nbsp; - &nbsp; Stake
+        </p>
+
+    </x-auth-card>
+
+
+    <script>
+        // get DOM elements
+        const button = document.getElementById('btn')
+        const payout = document.getElementById('payout')
+        const profit = document.getElementById('profit')
+        const oddTypeError = document.getElementById('odd_type_error')
+        const oddError = document.getElementById('odd_error')
+        const stakeError = document.getElementById('stake_error')
+
+        button.addEventListener('click', () => {
+            // get inputs
+            const oddType = document.getElementsByName('odd_type')
+            const odd = document.getElementById('odd').value
+            const stake = document.getElementById('stake').value
+
+            // reset error fields
+            oddTypeError.innerHTML = ''
+            oddError.innerHTML = ''
+            stakeError.innerHTML = ''
+
+            // reset and hide payout and profit fields
+            payout.innerHTML = ''
+            payout.style.display = "none"
+            profit.innerHTML = ''
+            profit.style.display = "none"
+
+            // check if any input field is empty
+            let emptyField = false
+
+            if (!oddType[0].checked && !oddType[1].checked) {
+
+                oddTypeError.innerHTML = 'The odd type field is required'
+                oddTypeError.style.display = "block"
+                emptyField = true
+
+            }
+
+            if (!odd) {
+
+                oddError.innerHTML = 'The odd field is required'
+                oddError.style.display = "block"
+                emptyField = true
+
+            }
+
+            if (!stake) {
+
+                stakeError.innerHTML = 'The stake field is required'
+                stakeError.style.display = "block"
+                emptyField = true
+
+            }
+
+            if (!emptyField) {
+
+                // if stake is in american format
+                if (oddType[0].checked) {
+
+                    // convert to decimal
+                    const decimalOdd = americanToDecimal(odd).toFixed(3)
+
+                    // calculations
+                    const payoutCalc = decimalOdd * stake
+                    const profitCalc = payoutCalc - stake
+
+                    // show results
+                    payout.innerHTML = 'Payout: ' + payoutCalc.toFixed(2)
+                    profit.innerHTML = 'Profit: ' + profitCalc.toFixed(2)
+
+                    // if stake is in decimal format 
+                } else if (oddType[1].checked) {
+
+                    // calculations
+                    const payoutCalc = odd * stake
+                    const profitCalc = payoutCalc - stake
+
+                    // set results body
+                    payout.innerHTML = 'Payout: ' + payoutCalc.toFixed(2)
+                    profit.innerHTML = 'Profit: ' + profitCalc.toFixed(2)
+
+                }
+
+                // show results
+                payout.style.display = "block"
+                profit.style.display = "block"
+
+            }
+
+        })
+
+        function americanToDecimal(odd) {
+            if (odd > 0) {
+                return (odd / 100) + 1
+            } else {
+                return (100 / Math.abs(odd)) + 1
+            }
+        }
+    </script>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,9 @@ Route::view('odds-comparison', 'odds-comparison')->name('odds-comparison');
 // odd converter page
 Route::view('odd-converter', 'odd-converter')->name('odd-converter');
 
+// payout calculator
+Route::view('payout-calculator', 'payout-calculator')->name('payout-calculator');
+
 // routes for registered users
 Route::middleware(['auth'])->group(function () {
     // index all bets (LIVEWIRE!!)

--- a/tests/Feature/Guest/OddsComparisonTest.php
+++ b/tests/Feature/Guest/OddsComparisonTest.php
@@ -4,9 +4,9 @@ namespace Tests\Feature\Guest;
 
 use Tests\TestCase;
 
-class ValueBetsTest extends TestCase
+class OddsComparisonTest extends TestCase
 {
-    public function test_value_bets_screen_can_be_rendered()
+    public function test_odds_comparison_screen_can_be_rendered()
     {
         $response = $this->get('/odds-comparison');
 

--- a/tests/Feature/Guest/PayoutCalculatorTest.php
+++ b/tests/Feature/Guest/PayoutCalculatorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class PayoutCalculatorTest extends TestCase
+{
+    /**
+     * test if payout-calculator page can be rendered
+     *
+     * @return void
+     */
+    public function test_payout_calculator_screen_can_be_rendered()
+    {
+        $response = $this->get('/payout-calculator');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -112,13 +112,13 @@ class StatsTest extends TestCase
 
         $bets = Bet::factory(5)->create(['user_id' => $user->id]);
 
-        $totalPayoffs = $bets->map(function ($bet) {
+        $totalPayouts = $bets->map(function ($bet) {
             if ($bet->result) {
-                return $bet->payoff() - $bet->bet_size;
+                return $bet->payout() - $bet->bet_size;
             }
         })->sum();
 
-        $this->actingAs($user)->get('/stats')->assertViewHas('totalGains', $totalPayoffs);
+        $this->actingAs($user)->get('/stats')->assertViewHas('totalGains', $totalPayouts);
     }
 
     public function test_total_losses()
@@ -143,19 +143,19 @@ class StatsTest extends TestCase
         $this->actingAs($user)->get('/stats')->assertViewHas('biggestBet', $biggestBet);
     }
 
-    public function test_biggest_payoff()
+    public function test_biggest_payout()
     {
         $user = User::factory()->create();
 
         $bets = Bet::factory(5)->create(['user_id' => $user->id]);
 
-        $biggestPayoff = $bets->map(function ($bet) {
+        $biggestPayout = $bets->map(function ($bet) {
             if ($bet->result === true) {
-                return $bet->payoff();
+                return $bet->payout();
             }
         })->max();
 
-        $this->actingAs($user)->get('/stats')->assertViewHas('biggestPayoff', $biggestPayoff);
+        $this->actingAs($user)->get('/stats')->assertViewHas('biggestPayout', $biggestPayout);
     }
 
     public function test_biggest_loss()
@@ -196,10 +196,10 @@ class StatsTest extends TestCase
 
         $profitArray = [];
 
-        // get loss or payoff for every bet
+        // get loss or payout for every bet
         foreach ($bets as $bet) {
             if ($bet->result === 1) {
-                $profitArray[] = $bet->payoff();
+                $profitArray[] = $bet->payout();
             } else if ($bet->result === 0) {
                 $profitArray[] = - ((float) $bet->bet_size);
             }


### PR DESCRIPTION
This pull request implements the payout calculator feature, which is a betting tool any visitor can use to quickly calculate the potential payout and profit of a bet. This tool lives in the payout-calculator page, but I have also changed the about view to include the description of this tool, added a test for the rendering of the view, and added the link on all navigation bars (mobile and desktop, auth and non-auth).

This pull request closes #41.